### PR TITLE
Fix invoking task with arguments

### DIFF
--- a/lib/rake_performance.rb
+++ b/lib/rake_performance.rb
@@ -7,7 +7,7 @@ module Rake
     def invoke(*args)
       start_time = Time.now
       puts "Task '#{@name}' started at #{start_time}"
-      old_invoke(args)
+      old_invoke(*args)
       end_time = Time.now
       puts "Task '#{@name}' ended at #{end_time}"
       puts "Total time taken: #{TimeHelper.time_difference(start_time, end_time)}" 


### PR DESCRIPTION
"args" is an array of all arguments, but when calling the old "invoke" we
need to unpack the array to individual arguments again.
